### PR TITLE
Add facts for the cluster name and the location of the haclus binary

### DIFF
--- a/lib/facter/clustername.rb
+++ b/lib/facter/clustername.rb
@@ -16,7 +16,7 @@ end
 Facter.add(:vcs_clustername) do
   setcode do
     if Facter.value(:hacluspath)
-      clustername = Facter::Util::Resolution.exec(Facter.value(:hacluspath) + ' -list | tr [:lower:] [:upper:]')
+      clustername = Facter::Util::Resolution.exec(Facter.value(:hacluspath) + ' -list | tr "[:lower:]" "[:upper:]"')
       clustername
     else
       false

--- a/lib/facter/clustername.rb
+++ b/lib/facter/clustername.rb
@@ -1,0 +1,25 @@
+Facter.add(:hacluspath) do
+  setcode do
+    haclus_path = Facter::Core::Execution.exec('which haclus 2>/dev/null')
+    if haclus_path == ""
+      if File.exist? '/opt/VRTSvcs/bin/haclus'
+        '/opt/VRTSvcs/bin/haclus'
+      else
+        false
+      end
+    else
+      haclus_path
+    end
+  end
+end
+
+Facter.add(:vcs_clustername) do
+  setcode do
+    if Facter.value(:hacluspath)
+      clustername = Facter::Util::Resolution.exec(Facter.value(:hacluspath) + ' -list')
+      clustername
+    else
+      false
+    end
+  end
+end

--- a/lib/facter/clustername.rb
+++ b/lib/facter/clustername.rb
@@ -16,7 +16,7 @@ end
 Facter.add(:vcs_clustername) do
   setcode do
     if Facter.value(:hacluspath)
-      clustername = Facter::Util::Resolution.exec(Facter.value(:hacluspath) + ' -list')
+      clustername = Facter::Util::Resolution.exec(Facter.value(:hacluspath) + ' -list | tr [:lower:] [:upper:]')
       clustername
     else
       false

--- a/lib/facter/clusternodes.rb
+++ b/lib/facter/clusternodes.rb
@@ -1,0 +1,26 @@
+Facter.add(:hasyspath) do
+  setcode do
+    hasys_path = Facter::Core::Execution.exec('which hasys 2>/dev/null')
+    if hasys_path == ""
+      if File.exist? '/opt/VRTSvcs/bin/hasys'
+        '/opt/VRTSvcs/bin/hasys'
+      else
+        false
+      end
+    else
+      hasys_path
+    end
+  end
+end
+
+Facter.add(:vcs_clusternodes) do
+  setcode do
+    if Facter.value(:hasyspath)
+      clusternodes = Facter::Util::Resolution.exec(Facter.value(:hasyspath) + ' -list')
+      clusternodes
+    else
+      false
+    end
+  end
+end
+

--- a/manifests/vcs.pp
+++ b/manifests/vcs.pp
@@ -73,11 +73,11 @@ class veritas::vcs (
   Package <| title == 'VRTSvcs' |> ->
   Package <| title == 'VRTScps' |> ->
   Package <| title == 'VRTSvcsag' |> ->
-  Package <| title == 'VRTSvcsdr' |> ->
+#  Package <| title == 'VRTSvcsdr' |> ->
   Package <| title == 'VRTSvcsea' |> ->
   Package <| title == 'VRTSsfmh' |> ->
   Package <| title == 'VRTSvbs' |> ->
-  Package <| title == 'VRTSvcswiz' |> ->
+#  Package <| title == 'VRTSvcswiz' |> ->
   Package <| title == 'VRTSsfcpi62' |>->
   class { 'veritas::vcs::install': }->
   class { 'veritas::vcs::service': }


### PR DESCRIPTION
The basic idea is to get the real cluster name from the system, even if not managed via the puppet-veritas module.
